### PR TITLE
Fixed incorrect container position on non fullscreen maps.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+[core]
+autocrlf = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-[core]
-autocrlf = true
+* text=auto

--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
   },
   "types": "./lib/index.d.ts",
   "scripts": {
+    "start": "vite",
     "build": "tsc && cp src/layerswitcher.css lib/",
     "test": "jest"
   },
   "author": "Russ Garrett",
+  "contributors": [
+    "Albert Willemsen"
+  ],
   "license": "ISC",
   "repository": {
     "url": "https://github.com/russss/maplibregl-layer-switcher",

--- a/src/layerswitcher.ts
+++ b/src/layerswitcher.ts
@@ -1,4 +1,4 @@
-import { el, mount } from 'redom'
+import { el, mount, unmount } from 'redom'
 import isEqual from 'lodash.isequal'
 import './layerswitcher.css'
 import URLHash from './urlhash'
@@ -155,10 +155,13 @@ class LayerSwitcher implements maplibregl.IControl {
       'aria-label': 'Layer Switcher'
     })
     button.onmouseover = () => {
-      var button_position = button.getBoundingClientRect()
-      this._container.style.top = button_position.top + 'px'
-      this._container.style.right = document.documentElement.clientWidth - button_position.right + 'px'
       this._container.classList.add('visible')
+
+      var button_bounds = button.getBoundingClientRect()
+      var container_bounds = this._container.getBoundingClientRect();
+
+      this._container.style.top = window.pageYOffset + button_bounds.top + 'px'
+      this._container.style.left = window.pageXOffset + button_bounds.right - container_bounds.width + 'px'
     }
     this._container.onmouseleave = () => {
       this._container.classList.remove('visible')
@@ -170,9 +173,11 @@ class LayerSwitcher implements maplibregl.IControl {
   }
 
   onRemove() {
-    this._container.parentNode?.removeChild(this._container)
+    unmount(document.body, this._container)
     this._map = undefined
   }
+
+  getDefaultPosition = (): maplibregl.ControlPosition => "top-right";
 
   _getLayerElement(item: Layer | LayerGroup): Node {
     if (item instanceof Layer) {


### PR DESCRIPTION
Hi Russ,

I wanted to use your component for my project.
But because my maps aren't fullscreen so the position of the container element was all wrong.

To replicate change the css in the `index.html`.
```css
body { min-width: 150vw; min-height: 150vh; font-family: sans-serif; }
#map { margin: 25vw 25vh; width: 100vw; height: 100vh; }
```

This code should fix the scroll position of the container.

With kind regards,
Albert Willemsen